### PR TITLE
Require ordereddict for py26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ elif sys.version_info[1] < 2:
 if sys.version_info[0] < 3 or sys.version_info[1] < 4:
     install_requires += ['enum34']
 
+if sys.version_info[0] == 2 and sys.version_info[1] < 7:
+    install_requires += ['ordereddict']
+
 try:
    import pypandoc
    readme = pypandoc.convert('README.md', 'rst')


### PR DESCRIPTION
### Without this:

```
$ mkvirtualenv -p $(which python2.6) pies-py26
...
$ pip install -e .
...
Successfully installed pies
Cleaning up...

$ \python
Python 2.6.7 (r267:88850, Oct 11 2012, 20:15:00)
[GCC 4.2.1 Compatible Apple Clang 4.0 (tags/Apple/clang-418.0.60)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pies.overrides import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pies/overrides.py", line 91, in <module>
    from ordereddict import OrderedDict
ImportError: No module named ordereddict
```
### With this:

```
$ pip install -e .
...
Successfully installed ordereddict pies
Cleaning up...

$ \python
Python 2.6.7 (r267:88850, Oct 11 2012, 20:15:00)
[GCC 4.2.1 Compatible Apple Clang 4.0 (tags/Apple/clang-418.0.60)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pies.overrides import *
>>> u
<function u at 0x1047a9938>
```
