### PR TITLE
tox.ini: Install local pies2overrides

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,14 @@ envlist = py26, py27, py32, py33, pypy
 commands = py.test {posargs}
 deps =
     pytest
+
+[py2]
+deps =
+    {[testenv]deps}
+    {toxinidir}/pies2overrides
+
+[testenv:py26]
+deps = {[py2]deps}
+
+[testenv:py27]
+deps = {[py2]deps}


### PR DESCRIPTION
This makes `tox` install the local version of `pies2overrides` instead of pulling it from PyPI.

This addresses the following comment:

https://github.com/timothycrosley/pies/pull/23#issuecomment-35893411
