### PR TITLE
.travis.yml: Run py.test, install pies2overrides for py2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
 language: python
 python:
+  - "pypy"
   - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"
-script: python setup.py test
+install:
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ||
+          $TRAVIS_PYTHON_VERSION == '2.7' ||
+          $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then
+      pip install ./pies2overrides;
+    fi
+script:
+  - pip install pytest
+  - py.test


### PR DESCRIPTION
This makes Travis run the one test that I added in PR #22.

Note that I install a local `pies2overrides`, as I did in PR #24 for tox, because we should test against the latest version cloned from git; not from PyPI.
